### PR TITLE
取り込みメールの本文をマウスで選択した部分で解析できるよう修正

### DIFF
--- a/app/controllers/biz_offer_controller.rb
+++ b/app/controllers/biz_offer_controller.rb
@@ -46,7 +46,18 @@ class BizOfferController < ApplicationController
       @biz_offer.import_mail = import_mail
       @biz_offer.business_partner_id = import_mail.business_partner_id
       @biz_offer.bp_pic_id = import_mail.bp_pic_id
-      AnalysisTemplate.analyze(params[:template_id], import_mail, [@biz_offer, @business]) unless params[:template_id].blank?
+
+      if !params[:template_id].blank?
+        if params[:from].blank? || params[:end].blank?
+          AnalysisTemplate.analyze(params[:template_id], import_mail, [@biz_offer, @business])
+        else
+          AnalysisTemplate.analyze_content(
+            params[:template_id],
+            import_mail.mail_body[params[:from], params[:end]],
+            [@biz_offer, @business]
+          )
+        end
+      end
     end
   end
 

--- a/app/models/analysis_template.rb
+++ b/app/models/analysis_template.rb
@@ -15,18 +15,22 @@ class AnalysisTemplate < ActiveRecord::Base
   #   各項目をインデントによって分類しハッシュを生成、キーに対して正規表現マッチを行う。
   #
   def AnalysisTemplate.analyze(analysis_template_id, import_mail, models)#biz_offer, business
-    
+    AnalysisTemplate.analyze_content(analysis_template_id, import_mail.mail_body, models)
+  end
+
+  def AnalysisTemplate.analyze_content(analysis_template_id, content, models)
+
     items = AnalysisTemplateItem.find(:all, :conditions => ["deleted = 0 and analysis_template_id = ?", analysis_template_id])
-    map = MailParser.new(import_mail.mail_body).classification_by_indent
+    map = MailParser.new(content).classification_by_indent
     
     map.each { |k, v|
       items.each {|item|
         if k =~ Regexp.new(item.pattern)
           models.each do |model|
             next unless model.class.name == item.target_table_name.classify
-  #            puts">>>>>>>>>>>>table_name  : "+model.class.name
-  #            puts">>>>>>>>>>>>column_name : "+at_item.target_column_name
-  #            puts">>>>>>>>>>>>value       : "+$1
+#            puts">>>>>>>>>>>>table_name  : "+model.class.name
+#            puts">>>>>>>>>>>>column_name : "+at_item.target_column_name
+#            puts">>>>>>>>>>>>value       : "+$1
             unless item.before_set_code.blank?
               eval <<-EOS
                 def AnalysisTemplate.before_set(model, item, str)
@@ -54,7 +58,6 @@ class AnalysisTemplate < ActiveRecord::Base
   end
 
 end
-
 
 class AnalysisTemplate::MailParser
 

--- a/app/views/analysis_template/list.html.erb
+++ b/app/views/analysis_template/list.html.erb
@@ -24,7 +24,7 @@
   <tr>
     <% if params[:mode] && params[:import_mail_id] %>
       <% if params[:target_id] %>
-        <td align=center><%= back_to_link_popup_mode "選択", :controller => params[:mode], :action => 'edit', :id => params[:target_id], :template_id => analysis_template, :import_mail_id => params[:import_mail_id] %></td>
+        <td align=center><%= back_to_link_popup_mode "選択", :controller => params[:mode], :action => 'edit', :id => params[:target_id], :template_id => analysis_template, :import_mail_id => params[:import_mail_id], :from => params[:from], :end => params[:end] %></td>
       <% else %>
         <td align=center><%= back_to_link_popup_mode "選択", :controller => params[:mode], :action => 'new', :template_id => analysis_template, :import_mail_id => params[:import_mail_id] %></td>
       <% end %>

--- a/app/views/import_mail/show.html.erb
+++ b/app/views/import_mail/show.html.erb
@@ -1,8 +1,8 @@
 <h1>取り込みメール詳細</h1>
 
-<%= link_to "案件照会作成", "#", :onclick => "disp_wide('#{url_for(:controller => 'analysis_template', :action => 'list', :popup => 1, :mode => 'biz_offer', :import_mail_id => @import_mail)}');return false" %> | 
-<%= link_to "人材所属作成", "#", :onclick => "disp_wide('#{url_for(:controller => 'analysis_template', :action => 'list', :popup => 1, :mode => 'bp_member', :import_mail_id => @import_mail)}');return false" %> | 
-<%= link_to "取引先作成", "#", :onclick => "disp_wide('#{url_for(:controller => 'business_partner', :action => 'new', :popup => 1, :import_mail_id => @import_mail)}');return false" %> | 
+<%= link_to "案件照会作成", url_for(:controller => 'analysis_template', :action => 'list', :popup => 1, :mode => 'biz_offer', :import_mail_id => @import_mail), :class => :analysis_mail_link %> | 
+<%= link_to "人材所属作成", url_for(:controller => 'analysis_template', :action => 'list', :popup => 1, :mode => 'bp_member', :import_mail_id => @import_mail), :class => :analysis_mail_link %> | 
+<%= link_to "取引先作成", url_for(:controller => 'business_partner', :action => 'new', :popup => 1, :import_mail_id => @import_mail), :class => :analysis_mail_link %> | 
 
 <table class="show_table">
 <% if @import_mail.business_partner %>
@@ -42,7 +42,7 @@
 </tr>
 
 <tr>
-  <td colspan=2><pre><%=h(@import_mail.mail_body) %></pre></td>
+  <td colspan=2><pre id="mail_body"><%=h(@import_mail.mail_body) %></pre></td>
 </tr>
 
 </table>
@@ -67,3 +67,44 @@
 
   <p></p>
 <%= link_or_back '戻る', :action => 'list' %>
+
+<script type="text/javascript">
+<!--
+
+// メールの本文がユーザに選択されている場合、その部分を解析テンプレートに渡す
+$(".analysis_mail_link").bind('click', function(event) {
+  var selectedText = null;
+  var selectionStart = null;
+  var selectionEnd = null;
+  var url = $(this).attr('href');
+
+  if (window.getSelection) {
+    var selection = window.getSelection();
+    selectedText = selection.toString();
+    selectionStart = selection.anchorOffset;
+    selectionEnd = selection.focusOffset;
+  } else if (document.selection) {  // for IE
+    range = document.selection.createRange();
+    selectedText = range.toString();
+    selectionStart = range.startOffset;
+    selectionEnd = range.endOffset;
+  }
+
+  // メールの文章が範囲選択されている場合
+  if (selectedText && $("#mail_body").text().indexOf(selectedText) != -1) {
+    if (!confirm("選択した本文で" + $(this).text() + "を行います")) {
+      event.preventDefault();
+      return false;
+    }
+    url += '&from=' + selectionStart + '&end=' + selectionEnd;
+  }
+
+  // 別ウインドウで表示
+  disp_wide(url);
+
+  event.preventDefault();
+  return false;
+});
+
+// -->
+</script>


### PR DESCRIPTION
マウスで選択しない場合は従来通り全文を解析
