### PR TITLE
[チケット#94 実装]

### DIFF
--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -29,12 +29,22 @@ class BpPicController < ApplicationController
     @bp_pic = BpPic.new
     business_partner = BusinessPartner.find(params[:business_partner_id])
     @bp_pic.business_partner = business_partner
+    
   end
 
   def create
     @bp_pic = BpPic.new(params[:bp_pic])
     set_user_column @bp_pic
     @bp_pic.save!
+    
+    if params[:import_mail_id]
+      ActiveRecord::Base.transaction do 
+        @import_mail = ImportMail.find(params[:import_mail_id])
+        @import_mail.bp_pic_id = @bp_pic.id
+        @import_mail.save!
+      end
+    end
+    
     flash[:notice] = 'BpPic was successfully created.'
     if params[:back_to].blank?
       redirect_to :action => 'list'

--- a/app/helpers/import_mail_helper.rb
+++ b/app/helpers/import_mail_helper.rb
@@ -87,4 +87,8 @@ module ImportMailHelper
     link_to text, url_for(:controller => 'business_partner', :action => 'new', :popup => 1, :import_mail_id => import_mail), :class => :analysis_mail_link
   end
   
+  def link_to_bp_pic_create(text, import_mail)
+    link_to text, url_for(:controller => :bp_pic, :action => :new, :popup => 1, :import_mail_id => import_mail, :business_partner_id => import_mail.business_partner_id), :class => :analysis_mail_link
+  end
+  
 end

--- a/app/views/bp_pic/_form.html.erb
+++ b/app/views/bp_pic/_form.html.erb
@@ -37,5 +37,9 @@
 <!--[eoform:bp_pic]-->
 <%= hidden_field 'bp_pic', 'lock_version' %>
 <%= hidden_field 'bp_pic', 'business_partner_id' %>
+<% if params[:import_mail_id] %>
+  <input type="hidden" name="import_mail_id" value="<%= params[:import_mail_id] %>">
+  <div style="color: gray;">※この取引先担当は、呼び出し元画面のメールに紐付きます。</div>
+<% end %>
 <%= back_to_field_tag %>
 

--- a/app/views/import_mail/show.html.erb
+++ b/app/views/import_mail/show.html.erb
@@ -1,7 +1,12 @@
 <h1>取り込みメール詳細</h1>
 <%= link_to_biz_create "案件照会作成", @import_mail  %> | 
 <%= link_to_hresource_create "人材所属作成", @import_mail  %> | 
-<%= link_to_bp_create "取引先作成", @import_mail %> | 
+<% if !@import_mail.business_partner_id %>
+  <%= link_to_bp_create "取引先/取引先担当作成", @import_mail %> | 
+<% elsif !@import_mail.bp_pic_id %>
+  <%= link_to_bp_pic_create "取引先担当作成", @import_mail %> | 
+<% else %>
+<% end %>
 
 <table class="show_table">
 <% if @import_mail.business_partner %>


### PR DESCRIPTION
取り込みメールとBP、BP担当との紐付きによって新規登録用のリンクの表示、非表示を切り替える。
