### PR TITLE
#259　メインメニューの配置を変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,11 +26,9 @@
               <li><%= link_to '取引先', :controller => '/bp_pic' %></li>
               <li><%= link_to '照会', :controller => '/biz_offer' %></li>
               <li><%= link_to '所属', :controller => '/bp_member' %></li>
+              <li><%= link_to 'タグ管理', :controller => '/tags' %></li>
               <li><%= link_to 'プロジェクト', :controller => '/project' %></li>
               <li><%= link_to '売り上げ集計', :controller => '/project', :action => :summary %></li>
-              <li><%= link_to '取り込みメール', :controller => '/import_mail' %></li>
-              <li><%= link_to '解析テンプレート', :controller => '/analysis_template' %></li>
-              <li><%= link_to 'タグ管理', :controller => '/tags' %></li>
             </ul>
           </li>
           <li class="dropdown">
@@ -38,6 +36,8 @@
             <ul class="dropdown-menu">
               <li><%= link_to 'メールグループ', :controller => '/bp_pic_groups' %></li>
               <li><%= link_to 'メールテンプレート', :controller => '/mail_templates' %></li>
+              <li><%= link_to '取り込みメール', :controller => '/import_mail' %></li>
+              <li><%= link_to '解析テンプレート', :controller => '/analysis_template' %></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,14 @@
               <li><%= link_to '売り上げ集計', :controller => '/project', :action => :summary %></li>
               <li><%= link_to '取り込みメール', :controller => '/import_mail' %></li>
               <li><%= link_to '解析テンプレート', :controller => '/analysis_template' %></li>
+              <li><%= link_to 'タグ管理', :controller => '/tags' %></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">メール<b class="caret"></b></a>
+            <ul class="dropdown-menu">
               <li><%= link_to 'メールグループ', :controller => '/bp_pic_groups' %></li>
               <li><%= link_to 'メールテンプレート', :controller => '/mail_templates' %></li>
-              <li><%= link_to 'タグ管理', :controller => '/tags' %></li>
             </ul>
           </li>
           <li class="dropdown">


### PR DESCRIPTION
変更点まとめ
- メールメニュー新設しメール関連項目を移行
- タグ管理を所属の下に移動
