### PR TITLE
#255 複数の担当者を同時にグループに追加する機能を実装

### DIFF
--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -159,25 +159,29 @@ class BpPicController < ApplicationController
     bp_pic_id_list = params[:ids]
     
     if bp_pic_id_list && !selected_group.nil?
+      
       bp_pic_id_list.each do |id|
         target = BpPic.find(id)
         target.into_group(selected_group.id)
       end
       
+      group_str = selected_group.bp_pic_group_name =~ /グループ$/ ? "" : "グループ"
       respond_to do |format|
-        group_str = selected_group.bp_pic_group_name =~ /グループ$/ ? "" : "グループ"
-        
-        format.html { redirect_to back_to, notice: "選択した取引先担当者が「#{selected_group.bp_pic_group_name}」#{group_str}に追加されました。" }
+        flash[:notice] = "#{bp_pic_id_list.length}人の取引先担当者が「#{selected_group.bp_pic_group_name}」#{group_str}に追加されました。"
+        format.html {redirect_to back_to}
       end
     elsif selected_group.nil?
       # グループが選択されていなければエラー
+      # View側でチェックしてるので、到達不可処理
       respond_to do |format|
-        format.html { redirect_to back_to, notice: 'グループが選択されていません。' }
+        flash[:warning] = '追加先グループが選択されていません。'        
+        format.html {redirect_to back_to}
       end
     else
       # IDのリストが取得できなければエラー
       respond_to do |format|
-        format.html { redirect_to back_to, notice: '取引先担当者が選択されていません。' }
+        flash[:warning] = '取引先担当者が選択されていません。'
+        format.html {redirect_to back_to}
       end
     end
   end

--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -153,6 +153,34 @@ class BpPicController < ApplicationController
     
     redirect_to(back_to || {:action => 'list'})
   end
+  
+  def add_bp_pic_into_selected_group
+    selected_group = BpPicGroup.find(params[:group_id])
+    # bp_pic_id_list = params[:ids].map{|id| id.to_i}
+    bp_pic_id_list = params[:ids]
+    
+    if bp_pic_id_list && !selected_group.nil?
+      bp_pic_id_list.each do |id|
+        target = BpPic.find(id)
+        target.into_group(selected_group)
+      end
+      
+      respond_to do |format|
+        format.html { redirect_to back_to, notice: "選択した取引先担当者が「#{selected_group.bp_pic_group_name}」グループに追加されました。" }
+      end
+    elsif selected_group.nil?
+      # グループが選択されていなければエラー
+      respond_to do |format|
+        format.html { redirect_to back_to, notice: 'グループが選択されていません。' }
+      end
+    else
+      # IDのリストが取得できなければエラー
+      respond_to do |format|
+        format.html { redirect_to back_to, notice: '取引先担当者が選択されていません。' }
+      end
+    end
+  end
+  
 private
   def valid_of_business_partner_id
     if params[:business_partner_id].blank?
@@ -168,5 +196,5 @@ private
     end
     trimed_bp_name
   end
-  
+
 end

--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -162,7 +162,7 @@ class BpPicController < ApplicationController
     if bp_pic_id_list && !selected_group.nil?
       bp_pic_id_list.each do |id|
         target = BpPic.find(id)
-        target.into_group(selected_group)
+        target.into_group(selected_group.id)
       end
       
       respond_to do |format|

--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -172,13 +172,14 @@ class BpPicController < ApplicationController
       end
     elsif selected_group.nil?
       # グループが選択されていなければエラー
-      # View側でチェックしてるので、到達不可処理
+      # View側でチェックしてるので、現状到達不可処理
       respond_to do |format|
         flash[:warning] = '追加先グループが選択されていません。'        
         format.html {redirect_to back_to}
       end
     else
       # IDのリストが取得できなければエラー
+      # View側でチェックしてるので、現状到達不可処理
       respond_to do |format|
         flash[:warning] = '取引先担当者が選択されていません。'
         format.html {redirect_to back_to}

--- a/app/controllers/bp_pic_controller.rb
+++ b/app/controllers/bp_pic_controller.rb
@@ -156,7 +156,6 @@ class BpPicController < ApplicationController
   
   def add_bp_pic_into_selected_group
     selected_group = BpPicGroup.find(params[:group_id])
-    # bp_pic_id_list = params[:ids].map{|id| id.to_i}
     bp_pic_id_list = params[:ids]
     
     if bp_pic_id_list && !selected_group.nil?
@@ -166,7 +165,9 @@ class BpPicController < ApplicationController
       end
       
       respond_to do |format|
-        format.html { redirect_to back_to, notice: "選択した取引先担当者が「#{selected_group.bp_pic_group_name}」グループに追加されました。" }
+        group_str = selected_group.bp_pic_group_name =~ /グループ$/ ? "" : "グループ"
+        
+        format.html { redirect_to back_to, notice: "選択した取引先担当者が「#{selected_group.bp_pic_group_name}」#{group_str}に追加されました。" }
       end
     elsif selected_group.nil?
       # グループが選択されていなければエラー

--- a/app/models/bp_pic.rb
+++ b/app/models/bp_pic.rb
@@ -70,4 +70,12 @@ class BpPic < ActiveRecord::Base
       b.save!
     end
   end
+  
+  def into_group(group_id)
+    if BpPicGroupDetail.where(bp_pic_group_id: group_id, bp_pic_id: self.id).blank?
+      group = BpPicGroupDetail.new(bp_pic_group_id: group_id, bp_pic_id: self.id)
+      group.save!
+    end
+  end
+  
 end

--- a/app/models/bp_pic_group.rb
+++ b/app/models/bp_pic_group.rb
@@ -32,5 +32,10 @@ class BpPicGroup < ActiveRecord::Base
       clone.save!
     end
   end
-
+  
+  # [[bp_pic_group_name, id]]
+  def BpPicGroup.available_group_list
+    BpPicGroup.where(deleted: 0).map {|group| [group.bp_pic_group_name, group.id.to_s]}
+  end
+  
 end

--- a/app/models/bp_pic_group.rb
+++ b/app/models/bp_pic_group.rb
@@ -35,7 +35,7 @@ class BpPicGroup < ActiveRecord::Base
   
   # [[bp_pic_group_name, id]]
   def BpPicGroup.available_group_list
-    BpPicGroup.where(deleted: 0).map {|group| [group.bp_pic_group_name, group.id.to_s]}
+    BpPicGroup.where(deleted: 0).map {|group| [group.bp_pic_group_name, group.id]}
   end
   
 end

--- a/app/views/bp_pic/list.html.erb
+++ b/app/views/bp_pic/list.html.erb
@@ -30,49 +30,49 @@
 <%= paginate(@bp_pics) %>
 
 <%= form_tag url_for(controller: :bp_pic, action: :add_bp_pic_into_selected_group), method: :post do %>
-    <%= hidden_field_tag 'back_to', request_url %>
-    <p>追加先グループ:
-      <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
-      <%= submit_tag '選択した取引先担当をグループに追加', :onclick => "if($('#group_id').val()==''){alert('グループを選択してください。');return false;}else if($('[name=\"ids[]\"]:checked').length <= 0){alert('取引先担当者を選択してください。');return false}else{if(!confirm('選択した担当者をグループに追加します。よろしいですか？')){return false;}}" %>
-    </p>
-<table class="list_table">
-  <tr>
-    <th></th>
-    <th><%=getShortName('bp_pics', 'business_partner_id') %></th>
-    <th <%= !popup? && "colspan=2"%>><%=getShortName('bp_pics', 'bp_pic_name') %></th>
-    <th><%=getShortName('bp_pics', 'tel_mobile') %></th>
-    <th><%=getShortName('bp_pics', 'email1') %></th>
-<% unless popup? %>
-    <th>初会</th>
-    <th>あ</th>
-    <th>更新</th>
-<% end %>
-  </tr>
+  <%= hidden_field_tag 'back_to', request_url %>
   
+  <p>追加先グループ:
+    <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
+    <%= submit_tag '選択した取引先担当をグループに追加', :onclick => "if($('#group_id').val()==''){alert('グループを選択してください。');return false;}else if($('[name=\"ids[]\"]:checked').length <= 0){alert('取引先担当者を選択してください。');return false}else{if(!confirm('選択した担当者をグループに追加します。よろしいですか？')){return false;}}" %>
+  </p>
 
-
-<% for bp_pic in @bp_pics %>
-  <tr>
-<% if popup? %>
-    <td><%= star_links(bp_pic.business_partner) %> <%= bp_pic.business_partner.business_partner_name %></td>
-    <td><%= star_links(bp_pic) %> <%=link_to h(bp_pic.usefulname), '#', :onClick => "setBpPicToParentWindow(#{bp_pic.id},'#{bp_pic.usefulname}', '#{bp_pic.business_partner_name}');return false;" %></td>
-<% else %>
-    <td><%= check_box_tag 'ids[]', bp_pic.id, false %></td>
-    <td><%= star_links(bp_pic.business_partner) %> <%=back_to_link bp_pic.business_partner.business_partner_name, {:controller => :business_partner, :action => :show, :id => bp_pic.business_partner} %></td>
-    <td style="border-right-color: silver;"><%= star_links(bp_pic) %> <%=back_to_link bp_pic.usefulname, {:action => :show, :id => bp_pic} %></td>
-    <td style="text-align:center;"><%= bp_pic_edit_icon(bp_pic) %></td>
-<% end %>
-    <td><%=h bp_pic.tel_mobile %></td>
-    <td><%=h bp_pic.email1 %></td>
-<% unless popup? %>
-    <td><%=h _date(bp_pic.contact_date) %></td>
-    <td style="text-align:center;"><%= back_to_link(image_tag(bp_pic.contact_mail? ? 'icon-check.png' : 'icon-emailforward.png'), conatct_mail_new_delivery_mail_path(bp_pic)) %></td>
-    <td><%=h _time(bp_pic.updated_at) %></td>
-<% end %>
-  </tr>
-<% end %>
-
-</table>
+  <table class="list_table">
+    <tr>
+      <th></th>
+      <th><%=getShortName('bp_pics', 'business_partner_id') %></th>
+      <th <%= !popup? && "colspan=2"%>><%=getShortName('bp_pics', 'bp_pic_name') %></th>
+      <th><%=getShortName('bp_pics', 'tel_mobile') %></th>
+      <th><%=getShortName('bp_pics', 'email1') %></th>  
+      <% unless popup? %>
+        <th>初会</th>
+        <th>あ</th>
+        <th>更新</th>
+      <% end %>
+    </tr>
+  
+    <% for bp_pic in @bp_pics %>
+      <tr>
+        <% if popup? %>
+          <td><%= star_links(bp_pic.business_partner) %> <%= bp_pic.business_partner.business_partner_name %></td>
+          <td><%= star_links(bp_pic) %> <%=link_to h(bp_pic.usefulname), '#', :onClick => "setBpPicToParentWindow(#{bp_pic.id},'#{bp_pic.usefulname}', '#{bp_pic.business_partner_name}');return false;" %></td>
+        <% else %>
+          <td><%= check_box_tag 'ids[]', bp_pic.id, false %></td>
+          <td><%= star_links(bp_pic.business_partner) %> <%=back_to_link bp_pic.business_partner.business_partner_name, {:controller => :business_partner, :action => :show, :id => bp_pic.business_partner} %></td>
+          <td style="border-right-color: silver;"><%= star_links(bp_pic) %> <%=back_to_link bp_pic.usefulname, {:action => :show, :id => bp_pic} %></td>
+          <td style="text-align:center;"><%= bp_pic_edit_icon(bp_pic) %></td>
+        <% end %>      
+        <td><%=h bp_pic.tel_mobile %></td>
+        <td><%=h bp_pic.email1 %></td>
+        <% unless popup? %>
+          <td><%=h _date(bp_pic.contact_date) %></td>
+          <td style="text-align:center;"><%= back_to_link(image_tag(bp_pic.contact_mail? ? 'icon-check.png' : 'icon-emailforward.png'), conatct_mail_new_delivery_mail_path(bp_pic)) %></td>
+          <td><%=h _time(bp_pic.updated_at) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+    
+  </table>
 <% end %>
 
 <%= paginate(@bp_pics) %>

--- a/app/views/bp_pic/list.html.erb
+++ b/app/views/bp_pic/list.html.erb
@@ -33,10 +33,11 @@
 
 <table class="list_table">
   <tr>
-<% unless popup? %>
-    <th></th>
-    <th><%=getShortName('bp_pics', 'business_partner_id') %></th>
-<% end %>
+    <% unless popup? %>
+      <th></th>
+      <th><%=getShortName('bp_pics', 'business_partner_id') %></th>
+    <% end %>
+    
     <th <%= !popup? && "colspan=2"%>><%=getShortName('bp_pics', 'bp_pic_name') %></th>
     <th><%=getShortName('bp_pics', 'tel_direct') %></th>
     <th><%=getShortName('bp_pics', 'tel_mobile') %></th>
@@ -46,33 +47,34 @@
     <th>更新</th>
   </tr>
   
-<%= form_tag url_for(controller: :bp_pic, action: :add_bp_pic_into_selected_group), method: :post do %>
-<%= hidden_field_tag 'back_to', request_url %>
-<p>
-  追加先グループ:
-  <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
-  <%= submit_tag '選択した取引先担当をグループに追加', :onclick => "if($('#group_id').val()==''){alert('グループを選択してください。');return false;}else{if(!confirm('選択した担当者をグループに追加します。よろしいですか？')){return false;}}" %>
-</p>
-<% for bp_pic in @bp_pics %>
-  <tr>
-<% if popup? %>
-    <td><%= star_links(bp_pic) %> <%=link_to h(bp_pic.usefulname), '#', :onClick => "setBpPicToParentWindow(#{bp_pic.id},'#{bp_pic.usefulname}');return false;" %></td>
-<% else %>
+  <%= form_tag url_for(controller: :bp_pic, action: :add_bp_pic_into_selected_group), method: :post do %>
+    <%= hidden_field_tag 'back_to', request_url %>
+    <p>追加先グループ:
+      <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
+      <%= submit_tag '選択した取引先担当をグループに追加', :onclick => "if($('#group_id').val()==''){alert('グループを選択してください。');return false;}else if($('[name=\"ids[]\"]:checked').length <= 0){alert('取引先担当者を選択してください。');return false}else{if(!confirm('選択した担当者をグループに追加します。よろしいですか？')){return false;}}" %>
+    </p>
+    
+    <% for bp_pic in @bp_pics %>
+      <tr>
+        <% if popup? %>
+          <td><%= star_links(bp_pic) %> <%=link_to h(bp_pic.usefulname), '#', :onClick => "setBpPicToParentWindow(#{bp_pic.id},'#{bp_pic.usefulname}');return false;" %></td>
+        <% else %>
+          <td><%= check_box_tag 'ids[]', bp_pic.id, false %></td>
+          <td><%= star_links(bp_pic.business_partner) %> <%=back_to_link bp_pic.business_partner.business_partner_name, {:controller => :business_partner, :action => :show, :id => bp_pic.business_partner} %></td>
+          <td style="border-right-color: silver;"><%= star_links(bp_pic) %> <%=back_to_link bp_pic.usefulname, {:action => :show, :id => bp_pic} %></td>
+          <td style="text-align:center;"><%= bp_pic_edit_icon(bp_pic) %></td>
+        <% end %>
+        
+        <td><%=h bp_pic.tel_direct %></td>
+        <td><%=h bp_pic.tel_mobile %></td>
+        <td><%=h bp_pic.email1 %></td>
+        <td><%=h _date(bp_pic.contact_date) %></td>
+        <td style="text-align:center;"><%= back_to_link(image_tag(bp_pic.contact_mail? ? 'icon-check.png' : 'icon-emailforward.png'), conatct_mail_new_delivery_mail_path(bp_pic)) %></td>
+        <td><%=h _time(bp_pic.updated_at) %></td>
+      </tr>
+    <% end %>
 
-    <td><%= check_box_tag 'ids[]', bp_pic.id, false %></td>
-    <td><%= star_links(bp_pic.business_partner) %> <%=back_to_link bp_pic.business_partner.business_partner_name, {:controller => :business_partner, :action => :show, :id => bp_pic.business_partner} %></td>
-    <td style="border-right-color: silver;"><%= star_links(bp_pic) %> <%=back_to_link bp_pic.usefulname, {:action => :show, :id => bp_pic} %></td>
-    <td style="text-align:center;"><%= bp_pic_edit_icon(bp_pic) %></td>
-<% end %>
-    <td><%=h bp_pic.tel_direct %></td>
-    <td><%=h bp_pic.tel_mobile %></td>
-    <td><%=h bp_pic.email1 %></td>
-    <td><%=h _date(bp_pic.contact_date) %></td>
-    <td style="text-align:center;"><%= back_to_link(image_tag(bp_pic.contact_mail? ? 'icon-check.png' : 'icon-emailforward.png'), conatct_mail_new_delivery_mail_path(bp_pic)) %></td>
-    <td><%=h _time(bp_pic.updated_at) %></td>
-  </tr>
-<% end %>
-<% end %>
+  <% end %>
 </table>
 
 <%= paginate(@bp_pics) %>

--- a/app/views/bp_pic/list.html.erb
+++ b/app/views/bp_pic/list.html.erb
@@ -51,7 +51,7 @@
 <p>
   追加先グループ:
   <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
-  <%= submit_tag '選択した取引先担当をグループに追加', confirm: "選択した取引先担当をグループに追加します。よろしいですか？" %>
+  <%= submit_tag '選択した取引先担当をグループに追加', :onclick => "if($('#group_id').val()==''){alert('グループを選択してください。');return false;}else{if(!confirm('選択した担当者をグループに追加します。よろしいですか？')){return false;}}" %>
 </p>
 <% for bp_pic in @bp_pics %>
   <tr>

--- a/app/views/bp_pic/list.html.erb
+++ b/app/views/bp_pic/list.html.erb
@@ -34,6 +34,7 @@
 <table class="list_table">
   <tr>
 <% unless popup? %>
+    <th></th>
     <th><%=getShortName('bp_pics', 'business_partner_id') %></th>
 <% end %>
     <th <%= !popup? && "colspan=2"%>><%=getShortName('bp_pics', 'bp_pic_name') %></th>
@@ -45,11 +46,20 @@
     <th>更新</th>
   </tr>
   
+<%= form_tag url_for(controller: :bp_pic, action: :add_bp_pic_into_selected_group), method: :post do %>
+<%= hidden_field_tag 'back_to', request_url %>
+<p>
+  追加先グループ:
+  <%= select_tag 'group_id', options_for_select(BpPicGroup.available_group_list), include_blank: true %>
+  <%= submit_tag '選択した取引先担当をグループに追加', confirm: "選択した取引先担当をグループに追加します。よろしいですか？" %>
+</p>
 <% for bp_pic in @bp_pics %>
   <tr>
 <% if popup? %>
     <td><%= star_links(bp_pic) %> <%=link_to h(bp_pic.usefulname), '#', :onClick => "setBpPicToParentWindow(#{bp_pic.id},'#{bp_pic.usefulname}');return false;" %></td>
 <% else %>
+
+    <td><%= check_box_tag 'ids[]', bp_pic.id, false %></td>
     <td><%= star_links(bp_pic.business_partner) %> <%=back_to_link bp_pic.business_partner.business_partner_name, {:controller => :business_partner, :action => :show, :id => bp_pic.business_partner} %></td>
     <td style="border-right-color: silver;"><%= star_links(bp_pic) %> <%=back_to_link bp_pic.usefulname, {:action => :show, :id => bp_pic} %></td>
     <td style="text-align:center;"><%= bp_pic_edit_icon(bp_pic) %></td>
@@ -61,6 +71,7 @@
     <td style="text-align:center;"><%= back_to_link(image_tag(bp_pic.contact_mail? ? 'icon-check.png' : 'icon-emailforward.png'), conatct_mail_new_delivery_mail_path(bp_pic)) %></td>
     <td><%=h _time(bp_pic.updated_at) %></td>
   </tr>
+<% end %>
 <% end %>
 </table>
 

--- a/test/unit/bp_pic_group_test.rb
+++ b/test/unit/bp_pic_group_test.rb
@@ -18,14 +18,21 @@ class BpPicGroupTest < ActiveSupport::TestCase
   
   test "create clone bp_pic_group" do
     clone = BpPicGroup.new(bp_pic_group_name: "test_group")
-    
+    source = BpPicGroup.where(id: 1, deleted: 0)
     
     assert_difference('BpPicGroupDetail.count') do
       clone.save!
       clone.create_clone_group(1)
     end
     
+    p source_first_detail = source.shift.bp_pic_group_details.shift
+    clone_first_detail = clone.bp_pic_group_details.shift
+    
     assert(!BpPicGroupDetail.where(bp_pic_group_id: clone.id).blank?)
+    # ↓validationで生成してるし異なるのはそもそも自明？
+    # assert_not_equal(source_first_detail.bp_pic_group_id, clone_first_detail.bp_pic_group_id)
+    assert_equal(source_first_detail.bp_pic_id, clone_first_detail.bp_pic_id)
+    assert_equal(source_first_detail.suspended, clone_first_detail.suspended)
   end
   
 end

--- a/test/unit/bp_pic_group_test.rb
+++ b/test/unit/bp_pic_group_test.rb
@@ -25,7 +25,7 @@ class BpPicGroupTest < ActiveSupport::TestCase
       clone.create_clone_group(1)
     end
     
-    p source_first_detail = source.shift.bp_pic_group_details.shift
+    source_first_detail = source.shift.bp_pic_group_details.shift
     clone_first_detail = clone.bp_pic_group_details.shift
     
     assert(!BpPicGroupDetail.where(bp_pic_group_id: clone.id).blank?)

--- a/test/unit/bp_pic_group_test.rb
+++ b/test/unit/bp_pic_group_test.rb
@@ -29,7 +29,7 @@ class BpPicGroupTest < ActiveSupport::TestCase
     clone_first_detail = clone.bp_pic_group_details.shift
     
     assert(!BpPicGroupDetail.where(bp_pic_group_id: clone.id).blank?)
-    # ↓validationで生成してるし異なるのはそもそも自明？
+    # ↓Associationで生成してるし異なるのはそもそも自明？
     # assert_not_equal(source_first_detail.bp_pic_group_id, clone_first_detail.bp_pic_group_id)
     assert_equal(source_first_detail.bp_pic_id, clone_first_detail.bp_pic_id)
     assert_equal(source_first_detail.suspended, clone_first_detail.suspended)


### PR DESCRIPTION
取引先画面から担当者選択チェックし、追加先グループを選択して追加ボタン押すと追加されます。
既に追加先グループに存在していた場合、何もせず追加しました表示のみ出ます。
