### PR TITLE
ハイフン削除のキャンセル

### DIFF
--- a/app/controllers/delivery_mails_controller.rb
+++ b/app/controllers/delivery_mails_controller.rb
@@ -51,7 +51,7 @@ EOS
     @delivery_mail.content += <<EOS
 
 
-
+-- 
 #{current_user.mail_signature}
 EOS
     end
@@ -246,7 +246,7 @@ EOS
     unless sales_pic.mail_signature.blank?
       @delivery_mail.content += <<EOS
 
-
+-- 
 #{sales_pic.mail_signature}
 EOS
     end


### PR DESCRIPTION
http://www.asahi-net.or.jp/~bd9y-ktu/htmlrel_f/dtd_f/rfc_f/rfc2646j.html

4.3.  Usenet署名変換
　本体とメッセージ署名間の分離行として"-- "を使用するUsenetニュースでの変
　換があります。署名の前にUsenet様式を内容とする流動書式メッセージを生成
　する場合、その分離行は、そのままで送信されます。これは特別なケースで；
　ダッシュ　ダッシュ　スペースからなる行（時に引用され）は流動書式とはみ
　なされません。
