### PR TITLE
指摘事項反映

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -195,12 +195,16 @@ tr.send {
   background-color: skyblue;
 }
 
+tr.is_send_target{
+  background-color: white !important;
+}
+
 .status_toggle{
   display: inline-block;
   padding-left: 16px;
   padding-right: 16px;
   font-weight: bold;
-  width: 3em;
+  width: 2em;
   vertical-align: middle;
   text-align: center;
   -webkit-border-radius: 5px;

--- a/app/views/bp_pic_groups/show.html.erb
+++ b/app/views/bp_pic_groups/show.html.erb
@@ -52,20 +52,21 @@
         <th><%= getLongName('business_partners', 'business_partner_name') %></th>
         <th><%= getLongName('bp_pics', 'bp_pic_name') %></th>
         <th><%= getLongName('bp_pics', 'memo') %></th>
+        <th style="width:1%">状態</th>
       </tr>
       <% @bp_pic_group.bp_pic_group_details.each do | detail | %>
         <tr id="<%= "tr_#{detail.id}"%>" style="background-color:<%= suspended_color(detail) %>">
-          <td style="white-space: nowrap;">
+          <td>
             <% if @delivery_mail %>
-              <%= check_box_tag 'bp_pic_ids[]', detail.bp_pic_id, !(detail.suspended? || detail.nondelivery?), { class: 'mail_status_check_box', style: 'margin-top: 0;margin-left: 5px;margin-right: 16px;' } %>
+              <%= check_box_tag 'bp_pic_ids[]', detail.bp_pic_id, !(detail.suspended? || detail.nondelivery?), { class: 'mail_status_check_box', onchange: "changeSendFlag(#{detail.id}, this.checked)" } %>
             <% else %>
               <%= check_box_tag 'ids[]', detail.id, false, style: 'margin-top: 0;margin-left: 5px;margin-right: 16px;' %>
             <% end %>
-            <span class='<%= "status_#{detail.id}" %>'><%= link_to "", {:controller => :bp_pic_group_details, :action => :suspend, :id => detail, :authenticity_token => form_authenticity_token}, :remote => true, :method => :put, :class => (detail.suspended? ? "status_toggle off" : "status_toggle on") %></span>
           </td>
           <td><%= star_links(detail.bp_pic.business_partner) %> <%= back_to_link detail.bp_pic.business_partner.business_partner_name, :controller => :business_partner, :action => :show, :id => detail.bp_pic.business_partner_id %></td>
           <td><%= star_links(detail.bp_pic) %> <%= back_to_link "#{detail.bp_pic.usefulname} <#{detail.bp_pic.email1}>", :controller => :bp_pic, :action => :show, :id => detail.bp_pic_id %></td>
           <td><%= detail.bp_pic.memo%></td>
+          <td><span class='<%= "status_#{detail.id}" %>'><%= link_to "", {:controller => :bp_pic_group_details, :action => :suspend, :id => detail, :authenticity_token => form_authenticity_token}, :remote => true, :method => :put, :class => (detail.suspended? ? "status_toggle off" : "status_toggle on") %></span></td>
         </tr>
       <% end %>
     </table>
@@ -85,16 +86,31 @@ function changeStatus(id, status){
   switch(status){
     case 'on' : 
       target_row.css('background-color', '<%=suspended_colors[0]%>');
-      target_checkbox.prop('checked', <%= @delivery_mail ? 'true' : 'false' %>);
+      <% if @delivery_mail %>
+      target_checkbox.prop('checked', true);
+      <% end %>
       break;
     case 'off' : 
       target_row.css('background-color', '<%=suspended_colors[1]%>');
-      target_checkbox.prop('checked', <%= @delivery_mail ? 'false' : 'true' %>);
+      <% if @delivery_mail %>
+      target_checkbox.prop('checked', false);
+      <% end %>
       break;
     default :
       return;
   }
   target_link.attr('class', 'status_toggle ' + status);
+  changeSendFlag(id, target_checkbox.prop('checked'));
+}
+
+function changeSendFlag(id, check){
+<% if @delivery_mail %>
+  if(check){
+    $('#tr_' + id).addClass('is_send_target')
+  }else{
+    $('#tr_' + id).removeClass('is_send_target')
+  }
+<% end %>
 }
 
 document.setBpPic = function(bp_pic){

--- a/app/views/import_mail/list.html.erb
+++ b/app/views/import_mail/list.html.erb
@@ -37,7 +37,6 @@
   </tr>
 <% for import_mail in @import_mails %>
   <tr <%= "bgcolor=lightgray" unless import_mail.wanted? %> id="tr_<%= import_mail.id %>">
-    <td><%=h _time(import_mail.received_at) %></td>
     <td style="overflow: hidden">
       <div style="overflow: hidden;height:1.5em;width:20em">
         <div style="width:1000px;"><%= import_mail.bp_pic_id.blank? ? "" : star_links(import_mail.bp_pic) %> <%= import_mail.bp_pic_id.blank? ? import_mail.mail_sender_name : link_to_bp_detail(import_mail) %></div>
@@ -51,8 +50,8 @@
     </td>
     <td><div style="width:2.5em"><%=import_mail.payment_text %></div></td>
     <td><div style="width:2.5em"><%=import_mail.age_text %></div></td>
-    <% st_short = import_mail.nearest_station_short %>
     <td style="overflow: hidden;"><div style="overflow: hidden;width:3em"><div rel="station_name" style="width:1000px;"><%= import_mail.nearest_station_short %></div><div></td>
+    <td><%=h _time(import_mail.received_at) %></td>
     <td align=center><%=raw '<span title="添付ファイルあり">○</span>' if import_mail.attachment? %></td>
     <td class='flag_container'>
       <%= build_flag_link("案", :biz_offer, :biz_offer_flg, import_mail) %>|<%= build_flag_link("人", :bp_member, :bp_member_flg, import_mail) %>|<%= build_flag_link("不", :unwanted, :unwanted, import_mail) %>


### PR DESCRIPTION
- [bp_pic_group][show]suspended状態変更ボタンを行の右端に修正
- [bp_pic_group][show]一覧画面から遷移した場合に、チェックボックスとボタンが連動しないように修正
- [bp_pic_group][show]メール送信から遷移した場合に、チェックボックスにチェックが入っている列がsuspended状態に関係なく白くなるように修正
- [import_mail][list]日時欄を行の右側に修正
