### PR TITLE
 #304　年齢正規化処理の実装

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,6 +53,12 @@ module ApplicationHelper
     end
   end
 
+  def _age(age)
+    # 「歳」が二重に表示された場合、DBに入ってるデータがおかしい
+    # DBに入れる段階で数値（String）のみにしておくこと
+    age.blank? ? age : age + "歳"
+  end
+
   def logged_in?
     auth_signed_in?
   end

--- a/app/models/human_resource.rb
+++ b/app/models/human_resource.rb
@@ -36,4 +36,22 @@ class HumanResource < ActiveRecord::Base
     Tag.update_tags!("human_resources", id, words.join(","))
     self.skill_tag = words.join(",")
   end
+
+  # 年齢はDBに入れる前に半角数字(String)のみにする
+  def HumanResource.normalize_age(str)
+    require 'zen2han'
+    unless str.blank?
+      Zen2Han.toHan(str).gsub(/[歳才]/, "")
+    else
+      str
+    end
+  end
+
+  def HumanResource.to_normalize_age_all!
+    HumanResource.where("age is not null").reject{|hr| hr.age.blank?}.map{|hr|
+      hr.age = HumanResource.normalize_age(hr.age)
+      hr.save!
+    }
+  end
+
 end

--- a/app/models/import_mail.rb
+++ b/app/models/import_mail.rb
@@ -171,7 +171,11 @@ class ImportMail < ActiveRecord::Base
   end
 
   def detect_ages_in(body)
-    StringUtil.detect_regex(body, /[0-9]+[才歳]/).sort.reverse.first.to_s.gsub("才","歳")
+    pattern = /((:?[1-9]|[１-９])(:?[0-9]|[０-９]))[才歳]/
+    StringUtil.detect_regex(body, pattern) {|match_str|
+      pattern.match(match_str)
+      $1.blank? ? $1 : NKF::nkf('-wm0Z1', $1)
+    }.sort.reverse.first
   end
 
   def detect_payments

--- a/app/models/import_mail.rb
+++ b/app/models/import_mail.rb
@@ -171,10 +171,11 @@ class ImportMail < ActiveRecord::Base
   end
 
   def detect_ages_in(body)
-    pattern = /((:?[1-9]|[１-９])(:?[0-9]|[０-９]))[才歳]/
-    StringUtil.detect_regex(body, pattern) {|match_str|
-      pattern.match(match_str)
-      $1.blank? ? $1 : NKF::nkf('-wm0Z1', $1)
+    search_pattern = /((:?[1-9]|[１-９])(:?[0-9]|[０-９]))[才歳]/
+    extraction_pattern = /([1-9][0-9])[歳才]/
+    StringUtil.detect_regex(body, search_pattern) {|match_str|
+      extraction_pattern.match(Zen2Han.toHan(match_str))
+      $1
     }.sort.reverse.first
   end
 

--- a/app/views/human_resource/_show.html.erb
+++ b/app/views/human_resource/_show.html.erb
@@ -21,7 +21,7 @@
   <th><%= getLongName('human_resources', 'tel2') %></th><td><%=h @human_resource.tel2 %></td>
 </tr>
 <tr>
-  <th><%= getLongName('human_resources', 'age') %></th><td><%=h @human_resource.age %></td>
+  <th><%= getLongName('human_resources', 'age') %></th><td><%=h _age(@human_resource.age) %></td>
 </tr>
 <tr>
   <th><%= getLongName('human_resources', 'birthday_date') %></th><td><%=h @human_resource.birthday_date %></td>

--- a/app/views/import_mail/list.html.erb
+++ b/app/views/import_mail/list.html.erb
@@ -50,7 +50,7 @@
       <div style="overflow: hidden;height:1.4em;"><span style="line-height: 90%;"><%= raw format_only_major_tags(import_mail.tag_text, @major_words) %></span></div>
     </td>
     <td><div style="width:2.5em"><%=import_mail.payment_text %></div></td>
-    <td><div style="width:2.5em"><%=import_mail.age_text %></div></td>
+    <td><div style="width:2.5em"><%=_age(import_mail.age_text) %></div></td>
     <% st_short = import_mail.nearest_station_short %>
     <td style="overflow: hidden;"><div style="overflow: hidden;width:3em"><div rel="station_name" style="width:1000px;"><%= import_mail.nearest_station_short %></div><div></td>
     <td align=center><%=raw '<span title="添付ファイルあり">○</span>' if import_mail.attachment? %></td>

--- a/test/fixtures/human_resources.yml
+++ b/test/fixtures/human_resources.yml
@@ -31,3 +31,168 @@ human_resources_1:
   updated_user: "initial"
   deleted_at: 
   deleted: 0
+human_resources_2:
+  id: 2
+  owner_id: 
+  human_resource_name: ""
+  human_resource_short_name: ""
+  human_resource_name_kana: ""
+  initial: "BB"
+  email: ""
+  tel1: ""
+  tel2: ""
+  age: "20才"
+  birthday_date: 
+  sex_type: ""
+  nationality: ""
+  railroad: ""
+  near_station: ""
+  max_move_time: ""
+  skill: ""
+  skill_tag: ""
+  qualification: ""
+  communication_type: "level5"
+  attendance: ""
+  human_resource_status_type: ""
+  starred: 
+  rating: 
+  memo: ""
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+human_resources_3:
+  id: 3
+  owner_id: 
+  human_resource_name: ""
+  human_resource_short_name: ""
+  human_resource_name_kana: ""
+  initial: "CC"
+  email: ""
+  tel1: ""
+  tel2: ""
+  age: "３0才"
+  birthday_date: 
+  sex_type: ""
+  nationality: ""
+  railroad: ""
+  near_station: ""
+  max_move_time: ""
+  skill: ""
+  skill_tag: ""
+  qualification: ""
+  communication_type: "level5"
+  attendance: ""
+  human_resource_status_type: ""
+  starred: 
+  rating: 
+  memo: ""
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+human_resources_4:
+  id: 4
+  owner_id: 
+  human_resource_name: ""
+  human_resource_short_name: ""
+  human_resource_name_kana: ""
+  initial: "DD"
+  email: ""
+  tel1: ""
+  tel2: ""
+  age: "4０歳"
+  birthday_date: 
+  sex_type: ""
+  nationality: ""
+  railroad: ""
+  near_station: ""
+  max_move_time: ""
+  skill: ""
+  skill_tag: ""
+  qualification: ""
+  communication_type: "level5"
+  attendance: ""
+  human_resource_status_type: ""
+  starred: 
+  rating: 
+  memo: ""
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+human_resources_5:
+  id: 5
+  owner_id: 
+  human_resource_name: ""
+  human_resource_short_name: ""
+  human_resource_name_kana: ""
+  initial: "EE"
+  email: ""
+  tel1: ""
+  tel2: ""
+  age: "５０歳"
+  birthday_date: 
+  sex_type: ""
+  nationality: ""
+  railroad: ""
+  near_station: ""
+  max_move_time: ""
+  skill: ""
+  skill_tag: ""
+  qualification: ""
+  communication_type: "level5"
+  attendance: ""
+  human_resource_status_type: ""
+  starred: 
+  rating: 
+  memo: ""
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+human_resources_6:
+  id: 6
+  owner_id: 
+  human_resource_name: ""
+  human_resource_short_name: ""
+  human_resource_name_kana: ""
+  initial: "FF"
+  email: ""
+  tel1: ""
+  tel2: ""
+  age: "その他"
+  birthday_date: 
+  sex_type: ""
+  nationality: ""
+  railroad: ""
+  near_station: ""
+  max_move_time: ""
+  skill: ""
+  skill_tag: ""
+  qualification: ""
+  communication_type: "level5"
+  attendance: ""
+  human_resource_status_type: ""
+  starred: 
+  rating: 
+  memo: ""
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0

--- a/test/fixtures/import_mails.yml
+++ b/test/fixtures/import_mails.yml
@@ -28,3 +28,153 @@ import_mails_1:
   updated_user: "initial"
   deleted_at: 
   deleted: 0
+import_mails_2:
+  id: 2
+  owner_id: 
+  business_partner_id: 1
+  bp_pic_id: 1
+  in_reply_to: ""
+  received_at: <%= Time.now.to_s(:db) %>
+  mail_subject: "subject2"
+  mail_body: "body2"
+  mail_from: "from2"
+  mail_sender_name: "sender2"
+  mail_to: ""
+  mail_cc: ""
+  mail_bcc: ""
+  message_source: "source2"
+  message_id: ""
+  biz_offer_flg: 
+  bp_member_flg: 
+  registed: 
+  unwanted: 
+  tag_text: ""
+  payment_text: ""
+  age_text: "20才"
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+import_mails_3:
+  id: 3
+  owner_id: 
+  business_partner_id: 1
+  bp_pic_id: 1
+  in_reply_to: ""
+  received_at: <%= Time.now.to_s(:db) %>
+  mail_subject: "subject3"
+  mail_body: "body3"
+  mail_from: "from3"
+  mail_sender_name: "sender3"
+  mail_to: ""
+  mail_cc: ""
+  mail_bcc: ""
+  message_source: "source3"
+  message_id: ""
+  biz_offer_flg: 
+  bp_member_flg: 
+  registed: 
+  unwanted: 
+  tag_text: ""
+  payment_text: ""
+  age_text: "３0才"
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+import_mails_4:
+  id: 4
+  owner_id: 
+  business_partner_id: 1
+  bp_pic_id: 1
+  in_reply_to: ""
+  received_at: <%= Time.now.to_s(:db) %>
+  mail_subject: "subject4"
+  mail_body: "body4"
+  mail_from: "from4"
+  mail_sender_name: "sender4"
+  mail_to: ""
+  mail_cc: ""
+  mail_bcc: ""
+  message_source: "source4"
+  message_id: ""
+  biz_offer_flg: 
+  bp_member_flg: 
+  registed: 
+  unwanted: 
+  tag_text: ""
+  payment_text: ""
+  age_text: "4０歳"
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+import_mails_5:
+  id: 5
+  owner_id: 
+  business_partner_id: 1
+  bp_pic_id: 1
+  in_reply_to: ""
+  received_at: <%= Time.now.to_s(:db) %>
+  mail_subject: "subject5"
+  mail_body: "body5"
+  mail_from: "from5"
+  mail_sender_name: "sender5"
+  mail_to: ""
+  mail_cc: ""
+  mail_bcc: ""
+  message_source: "source5"
+  message_id: ""
+  biz_offer_flg: 
+  bp_member_flg: 
+  registed: 
+  unwanted: 
+  tag_text: ""
+  payment_text: ""
+  age_text: "５０歳"
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0
+import_mails_6:
+  id: 6
+  owner_id: 
+  business_partner_id: 1
+  bp_pic_id: 1
+  in_reply_to: ""
+  received_at: <%= Time.now.to_s(:db) %>
+  mail_subject: "subject6"
+  mail_body: "body6"
+  mail_from: "from6"
+  mail_sender_name: "sender6"
+  mail_to: ""
+  mail_cc: ""
+  mail_bcc: ""
+  message_source: "source6"
+  message_id: ""
+  biz_offer_flg: 
+  bp_member_flg: 
+  registed: 
+  unwanted: 
+  tag_text: ""
+  payment_text: ""
+  age_text: "その他"
+  created_at: <%= Time.now.to_s(:db) %>
+  updated_at: <%= Time.now.to_s(:db) %>
+  lock_version: 0
+  created_user: "initial"
+  updated_user: "initial"
+  deleted_at: 
+  deleted: 0

--- a/test/unit/import_mail_test.rb
+++ b/test/unit/import_mail_test.rb
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+
+require 'test_helper'
+
+class ImportMailTest < ActiveSupport::TestCase
+  
+  # test "shoud normalize age when import mail" do
+  # 	# テスト用メールソースの作成が必要
+  # end
+
+  test "shoud normalize age_text when execute to_normalize_age_all!" do
+  	ImportMail.to_normalize_age_all!
+  	assert_equal("20", ImportMail.find(2).age_text)
+  	assert_equal("30", ImportMail.find(3).age_text)
+  	assert_equal("40", ImportMail.find(4).age_text)
+  	assert_equal("50", ImportMail.find(5).age_text)
+  	assert_equal("その他", ImportMail.find(6).age_text)
+  end
+
+end


### PR DESCRIPTION
##### 既存データの年齢を正規化する処理を追加
- 数字（String型）のみDBに持つ
- 対象は人材と取り込みメール
##### 「歳」をview側で追加する処理を追加
- 必要に応じて使う
##### テストを追加
- DBのデータを直接書き換えるため、念入りに
