### PR TITLE
#314 案件照会と人材所属のスキルタグに関する表示を変更

### DIFF
--- a/app/views/biz_offer/list.html.erb
+++ b/app/views/biz_offer/list.html.erb
@@ -58,8 +58,7 @@
     <td><%=h biz_offer.business_partner.blank? ? "" : back_to_link(biz_offer.business_partner.business_partner_code_name,controller: :business_partner, action: :show, id: biz_offer.business_partner.id) %></td>
     <td><%=h biz_offer.bp_pic.blank? ? "" : back_to_link(biz_offer.bp_pic.bp_pic_name, controller: :bp_pic, action: :show, id: biz_offer.bp_pic.id) %></td>
     <td><%= star_links(biz_offer.business) %> <%=back_to_link h(biz_offer.business.business_title), :action => :show, :id => biz_offer %></td>
-    <td><div style="overflow: hidden;height:1.4em"><span style="line-height: 90%;"><%= biz_offer.business.skill_tag %></span></div>
-    </td>
+    <td><div style="overflow: hidden;height:1.4em"><span style="line-height: 90%;"><%= raw format_only_major_tags(biz_offer.business.skill_tag, @major_words) %></span></div></td>
     <td><%=h biz_offer.business.age_limit %></td>
     <td><%=h biz_offer.payment_text %></td>
     <td><%=h biz_offer.business.place %></td>

--- a/app/views/business/_show.html.erb
+++ b/app/views/business/_show.html.erb
@@ -46,6 +46,9 @@
   <th><%= getLongName('businesses', 'skill_want') %></th><td><%=simple_format h(@business.skill_want) %></td>
 </tr>
 <tr>
+  <th><%= getLongName('businesses', 'skill_tag') %></th><td><div style="overflow: hidden;height:1.4em"><span style="line-height: 90%;"><%= raw format_only_major_tags(@business.skill_tag, @major_words) %></span></div></td>
+</tr>
+<tr>
   <th><%= getLongName('businesses', 'business_hours') %></th><td><%=h @business.business_hours %></td>
 </tr>
 <tr>

--- a/app/views/human_resource/_show.html.erb
+++ b/app/views/human_resource/_show.html.erb
@@ -45,7 +45,7 @@
   <th><%= getLongName('human_resources', 'skill') %></th><td><%=simple_format h(@human_resource.skill) %></td>
 </tr>
 <tr>
-  <th><%= getLongName('human_resources', 'skill_tag') %></th><td><%= @human_resource.skill_tag %></td>
+  <th><%= getLongName('human_resources', 'skill_tag') %></th><td><div style="overflow: hidden;height:1.4em"><span style="line-height: 90%;"><%= raw format_only_major_tags(@human_resource.skill_tag, @major_words) %></span></div></td>
 </tr>
 <tr>
   <th><%= getLongName('human_resources', 'qualification') %></th><td><%=simple_format h(@human_resource.qualification) %></td>


### PR DESCRIPTION
取り込みメール画面に合せる形で表示を変更
