### PR TITLE
#408 import mail の折り返し対応

### DIFF
--- a/app/views/import_mail/list.html.erb
+++ b/app/views/import_mail/list.html.erb
@@ -45,7 +45,7 @@
       </div>
     </td>
     <td style="overflow: hidden">
-      <div style="overflow: hidden;height:1.5em">
+      <div style="overflow: hidden;height:1.5em;word-wrap: break-word;word-break: break-all;">
         <%= link_to_detail(import_mail, request_url) %>
       </div>
     </td>


### PR DESCRIPTION
件名に
word-wrap: break-word;word-break: break-all;
を指定したらうまくいった。
