### PR TITLE
#464, #484 配信メールに紐づく返信メールのソート、取引先担当グループに担当者を追加する際の重複チェック

### DIFF
--- a/app/controllers/bp_pic_group_details_controller.rb
+++ b/app/controllers/bp_pic_group_details_controller.rb
@@ -42,13 +42,18 @@ class BpPicGroupDetailsController < ApplicationController
   # POST /bp_pic_group_details.json
   def create
     @bp_pic_group_detail = BpPicGroupDetail.new(params[:bp_pic_group_detail])
-    
+
     if @bp_pic_group_detail.bp_pic_id
       respond_to do |format|
         begin
-          @bp_pic_group_detail.save!
-          format.html { redirect_to back_to, notice: 'Bp pic group detail was successfully created.' }
-          format.json { render json: @bp_pic_group_detail, status: :created, location: @bp_pic_group_detail }
+          if BpPicGroupDetail.where(:deleted => 0, :bp_pic_group_id => @bp_pic_group_detail.bp_pic_group_id, :bp_pic_id => @bp_pic_group_detail.bp_pic_id).blank?
+            @bp_pic_group_detail.save!
+            format.html { redirect_to back_to, notice: 'Bp pic group detail was successfully created.' }
+            format.json { render json: @bp_pic_group_detail, status: :created, location: @bp_pic_group_detail }
+          else
+            format.html { redirect_to back_to, notice: '選択された取引先担当は既に登録済みのため追加できません。' }
+            format.json { render json: @bp_pic_group_detail.errors, status: :unprocessable_entity }
+          end
         rescue ActiveRecord::RecordInvalid
           format.html { render action: "new" }
           format.json { render json: @bp_pic_group_detail.errors, status: :unprocessable_entity }

--- a/app/controllers/delivery_mails_controller.rb
+++ b/app/controllers/delivery_mails_controller.rb
@@ -24,6 +24,15 @@ class DeliveryMailsController < ApplicationController
   # GET /delivery_mails/1.json
   def show
     @delivery_mail = DeliveryMail.find(params[:id]).get_informations
+    @delivery_mail.delivery_mail_targets.each do |delivery_mail_target|
+      delivery_mail_target.get_reply_import_mail
+    end
+    if @delivery_mail.delivery_mail_targets.size > 1
+      @delivery_mail.delivery_mail_targets.sort_by! do |delivery_mail_target|
+        delivery_mail_target.get_import_mail_id.nil? ? 0 : - delivery_mail_target.get_import_mail_id
+      end
+    end
+
     @attachment_files = AttachmentFile.attachment_files("delivery_mails", @delivery_mail.id)
     
     respond_to do |format|

--- a/app/models/delivery_mail_target.rb
+++ b/app/models/delivery_mail_target.rb
@@ -5,6 +5,10 @@ class DeliveryMailTarget < ActiveRecord::Base
   attr_accessible :bp_pic_id, :delivery_mail_id, :id, :owner_id
 
   def get_reply_import_mail
-    ImportMail.where(:in_reply_to => message_id).first if message_id
+    @import_mail = ImportMail.where(:in_reply_to => self.message_id).first if self.message_id
+  end
+
+  def get_import_mail_id
+    @import_mail.nil? ? nil : @import_mail.id
   end
 end

--- a/app/views/delivery_mails/show.html.erb
+++ b/app/views/delivery_mails/show.html.erb
@@ -64,13 +64,12 @@
           %></td>
         <% else %>
           <td>
-            <% dmt = delivery_mail_target.get_reply_import_mail %>
-            <% if dmt != nil %>
+            <% if delivery_mail_target.get_import_mail_id != nil %>
               <%=
                 back_to_link "詳細",
                 :controller => :import_mail,
                 :action => :show,
-                :id => dmt.id
+                :id => delivery_mail_target.get_import_mail_id
               %>
             <% else %>
               &nbsp;


### PR DESCRIPTION
#464 修正:配信メールに紐づく返信メールのソート
#484 修正:取引先担当グループに担当者を追加する際の重複チェック
