### PR TITLE
#522 #523 #526

### DIFF
--- a/app/controllers/delivery_mails_controller.rb
+++ b/app/controllers/delivery_mails_controller.rb
@@ -62,11 +62,19 @@ class DeliveryMailsController < ApplicationController
     @delivery_mail = DeliveryMail.new
     @delivery_mail.bp_pic_group_id = params[:bp_pic_group_id]
     if (target_mail_template = get_target_mail_template)
-      p target_mail_template
       @delivery_mail.content = target_mail_template.content
       @delivery_mail.subject = target_mail_template.subject
       @delivery_mail.mail_cc = target_mail_template.mail_cc
       @delivery_mail.mail_bcc = target_mail_template.mail_bcc
+
+      unless current_user.mail_signature.blank?
+        @delivery_mail.content += <<EOS
+
+
+--
+#{current_user.mail_signature}
+EOS
+      end
     else
       @delivery_mail.content = <<EOS
 %%business_partner_name%%

--- a/app/models/attachment_file.rb
+++ b/app/models/attachment_file.rb
@@ -121,10 +121,12 @@ class AttachmentFile < ActiveRecord::Base
     database = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]['database']
 
     author = SysConfig.get_company_name
-    command = "java -classpath #{class_path} gd/SetPoiProperty jdbc:mysql://#{host}:3306/#{database} #{username} #{password} #{target_attachment_ids.join(',')} #{Rails.root} #{author}"
 
-    logger.debug(command)
-    result = `#{command}`
+    unless author.nil? || author.size == 0
+      command = "java -classpath #{class_path} gd/SetPoiProperty jdbc:mysql://#{host}:3306/#{database} #{username} #{password} #{target_attachment_ids.join(',')} #{Rails.root} #{author}"
+      logger.debug(command)
+      result = `#{command}`
+    end
   end
 
 private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,7 @@
               <li><%= link_to '取り込みメール', :controller => '/import_mail' %></li>
               <li><%= link_to '解析テンプレート', :controller => '/analysis_template' %></li>
               <li><%= link_to 'タグ管理', :controller => '/tags' %></li>
+              <li><%= link_to '流出メール解析', :controller => '/outflow_mail/new' %></li>
             </ul>
           </li>
           <li class="dropdown">

--- a/app/views/outflow_mail/new.html.erb
+++ b/app/views/outflow_mail/new.html.erb
@@ -1,0 +1,52 @@
+<%= content_tag :h1, getLongName('table_name', 'outflow_mails') + ' 解析' %>
+
+<%= content_tag :p, '流出メールのアドレスをカンマ(,)区切りで入力して解析ボタンをクリックしてください。' %>
+<%= form_tag(:action => 'analyze_outflow_mail') do %>
+
+<%= text_area 'outflow_mail_list', '', :value => @outflow_mail_list_raw.nil? ? '' : @outflow_mail_list_raw, :style => "width:600px;", :rows => 10 %>
+
+<%= button_to '解析' %>
+
+<% end %>
+
+<%= paginate_far(@import_mails) %>
+<table class="list_table">
+  <tr>
+    <th colspan="9">取り込みメール一覧</th>
+  </tr>
+  <% for import_mail in @import_mails %>
+    <tr <%= "bgcolor=lightgray" unless import_mail.wanted? %> id="tr_<%= import_mail.id %>">
+      <td style="overflow: hidden">
+        <div class="overflow_hidden" style="width:20em;">
+          <div style="width:1000px;"><%= import_mail.bp_pic_id.blank? ? "" : star_links(import_mail.bp_pic) %> <%= import_mail.bp_pic_id.blank? ? import_mail.mail_sender_name : link_to_bp_detail(import_mail) %></div>
+        </div>
+      </td>
+      <td style="overflow: hidden">
+        <div class="overflow_hidden">
+          <% if import_mail.outflow_mail_flg == 1 %>
+            <%= button_to '流出', {:controller => :outflow_mail, :action => :list, :import_mail_id => import_mail.id}, {class: 'btn btn-danger btn-mini',style: 'line-height:14px;'}  %>
+          <% end %>
+          <%= star_links import_mail %> <%= link_to h(import_mail.mail_subject), {:controller => 'import_mail', :action => :show, :id => import_mail, :back_to => request_url}, :title => import_mail.mail_subject %>
+        </div>
+      </td>
+      <td>
+        <div style="overflow: hidden;height:1.4em"><span style="line-height: 90%;"><%= raw format_only_major_tags(import_mail.tag_text, @major_words) %></span></div>
+      </td>
+      <td><div style="width:2.5em"><%=import_mail.payment_text %></div></td>
+      <td><div style="width:2.5em"><%=_age(import_mail.age_text) %></div></td>
+      <td style="overflow: hidden;">
+        <div style="overflow: hidden;width:3em">
+          <div rel="station_name" style="width:1000px;" title="<%=import_mail.nearest_station%>"><%= import_mail.nearest_station_short %></div>
+        </div>
+      </td>
+      <td><%=h _time(import_mail.received_at) %></td>
+      <td align=center><%=raw '<span title="添付ファイルあり">○</span>' if import_mail.attachment? %></td>
+      <td class='flag_container'>
+        <%= build_flag_link("案", :biz_offer, :biz_offer_flg, import_mail) %>|<%= build_flag_link("人", :bp_member, :bp_member_flg, import_mail) %>|<%= build_flag_link("不", :unwanted, :unwanted, import_mail) %>
+      </td>
+
+    </tr>
+  <% end %>
+</table>
+
+<%= paginate_far(@import_mails) %>


### PR DESCRIPTION
#522 修正:[メールテンプレート]案件人材紐付けの修正検討
#523 追加:[流出メール]取り込みメールとは別に管理ができるようにする。
#526 修正:添付ファイルの自動書き換えをSysconfigの内容で処理の有無を分けるようにする。
