### PR TITLE
面談回数解析 修正

### DIFF
--- a/app/controllers/import_mail_controller.rb
+++ b/app/controllers/import_mail_controller.rb
@@ -203,7 +203,7 @@ private
       :age_to => params[:age_to],
       :free_word => params[:free_word],
       :days => params[:days],
-      :interviewing_count_one => params[:interviewing_count_one],
+      :interview_count_one => params[:interview_count_one],
       :order_by => params[:order_by],
     }
   end
@@ -249,8 +249,8 @@ private
       sql += " and proper_flg = 1"
     end
 
-    unless cond_param[:interviewing_count_one].blank?
-      sql += " and interviewing_count = 1 "
+    unless cond_param[:interview_count_one].blank?
+      sql += " and interview_count = 1 "
     end
 
     unless cond_param[:tag].blank?

--- a/app/models/import_mail.rb
+++ b/app/models/import_mail.rb
@@ -341,12 +341,12 @@ EOS
     return false
   end
 
-  def detect_interviewing_count_in(body)
+  def detect_interview_count_in(body)
     pattern = /(面\s*?[談接]|打ち?合わ?せ).*?(?<count>\d)[^\n\d]*?回/m
     if (m = pattern.match(body))
       return m[:count]
     end
-    return self.interviewing_count
+    return self.interview_count
   end
 
   # 人材判定用特別単語でbodyを検索して1件でもhitすれば、人材メールと判断
@@ -380,7 +380,7 @@ EOS
     self.tag_text = make_tags(body)
     self.subject_tag_text = make_tags(Tag.pre_proc_body(mail_subject))
     self.proper_flg = detect_proper_in(body) ? 1 : 0
-    self.interviewing_count = detect_interviewing_count_in(body) 
+    self.interview_count = detect_interview_count_in(body) 
   end
 
   # 解析とともに保存を行う

--- a/app/models/import_mail.rb
+++ b/app/models/import_mail.rb
@@ -585,6 +585,10 @@ EOS
     bp_member_flg == 1
   end
 
+  def interview_count_one?
+    interview_count == 1
+  end
+
 private
   def ImportMail.get_encode_body(mail, body)
     if mail.content_transfer_encoding == 'ISO-2022-JP'

--- a/app/views/import_mail/_td_tags.html.erb
+++ b/app/views/import_mail/_td_tags.html.erb
@@ -1,5 +1,5 @@
     <td style="overflow: hidden">
       <div class="overflow_hidden">
-        <span style="line-height: 90%;"><% if import_mail.plural? %><span class="label label-danger tag">複数</span> <%end%><% if import_mail.delivery_mail_matches.exists? %><span class="label label-default tag">候補</span> <% end %><% if import_mail.proper? then %><span class="label label-danger tag">社員</span> <%end%><%= raw format_only_major_tags(import_mail.tag_text) %></span></div>
+        <span style="line-height: 90%;"><% if import_mail.interview_count_one? %><span class="label label-danger tag">一回</span> <% end %><% if import_mail.plural? %><span class="label label-danger tag">複数</span> <%end%><% if import_mail.delivery_mail_matches.exists? %><span class="label label-default tag">候補</span> <% end %><% if import_mail.proper? then %><span class="label label-danger tag">社員</span> <%end%><%= raw format_only_major_tags(import_mail.tag_text) %></span></div>
     </td>
 

--- a/app/views/import_mail/list.html.erb
+++ b/app/views/import_mail/list.html.erb
@@ -48,7 +48,7 @@
     <tr>
       <th><i class="fa fa-angle-double-right "></i>面談回数</th>
       <td>
-        <%= check_box_tag 'interviewing_count_one', 1, session[:import_mail_search][:interviewing_count_one].to_i == 1 %> 面談1回
+        <%= check_box_tag 'interview_count_one', 1, session[:import_mail_search][:interview_count_one].to_i == 1 %> 面談1回
       </td>
     </tr>
     <tr>

--- a/app/views/import_mail/list.html.erb
+++ b/app/views/import_mail/list.html.erb
@@ -11,6 +11,7 @@
         <%= check_box_tag 'proper_flg', 1, session[:import_mail_search][:proper_flg].to_i == 1 %> プロパー
         <%= check_box_tag 'starred', 1, session[:import_mail_search][:starred].to_i == 1 %> スター
         <%= check_box_tag 'outflow_mail_flg', 1, session[:import_mail_search][:outflow_mail_flg].to_i == 1 %> 流出メール
+        <%= check_box_tag 'interview_count_one', 1, session[:import_mail_search][:interview_count_one].to_i == 1 %> 面談1回
       </td>
     </tr>
     <tr>
@@ -43,12 +44,6 @@
       <th><i class="fa fa-angle-double-right "></i>対象日数</th>
       <td>
         <%= select_tag 'days', options_for_select((1..4).to_a + (1..6).to_a.map{|x| x*5}.push("無制限"), (session[:import_mail_search][:days] || 5))%>
-      </td>
-    </tr>
-    <tr>
-      <th><i class="fa fa-angle-double-right "></i>面談回数</th>
-      <td>
-        <%= check_box_tag 'interview_count_one', 1, session[:import_mail_search][:interview_count_one].to_i == 1 %> 面談1回
       </td>
     </tr>
     <tr>

--- a/test/unit/import_mail_test.rb
+++ b/test/unit/import_mail_test.rb
@@ -50,59 +50,59 @@ EOS
     assert_equal(1, im.delivery_mail_id)
   end
 
-  test "detect_interviewing_count" do
+  test "detect_interview_count" do
     ### 面談回数不明パターン  
-    assert_detect_interviewing_count(<<EOS, 0)
+    assert_detect_interview_count(<<EOS, 0)
 ・面談回数　：
 ・社員区分　：正社員,契約社員
 EOS
 
     ### 通常パターン
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
     単価　@50（140-180、スキルにより柔軟に増額可）
     面談　1回（弊社同席）　※即設定可能
     人数　1名
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 2)
+    assert_detect_interview_count(<<EOS, 2)
 ・面　談　　：２回
 ・備　考　　：外国籍可
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 　　　　　　　　　　■面談回数１回
 　　　　　　　　　　■単価６０万程度（固定）
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 　■面談・・・・・・１回
 　■単価・・・・・・６０万程度（固定）
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 ・面接回数　：1回
 ・備　考　　：外国籍可
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 3)
+    assert_detect_interview_count(<<EOS, 3)
 ・打ち合わせ：3回
 ・備　考　　：外国籍可
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 ・打合せ　　：1回
 ・備　考　　：外国籍不可
 EOS
 
     ### 2行パターン
-    assert_detect_interviewing_count(<<EOS, 2)
+    assert_detect_interview_count(<<EOS, 2)
 ■面談回数
 2回
 ■年齢
 EOS
 
     ### 3行パターン
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 ■面談回数
    
 1回
@@ -110,7 +110,7 @@ EOS
 EOS
 
     ### 4行パターン
-    assert_detect_interviewing_count(<<EOS, 3)
+    assert_detect_interview_count(<<EOS, 3)
 ■面談回数
    
    
@@ -119,24 +119,24 @@ EOS
 EOS
 
     ### 複数回数パターン
-    assert_detect_interviewing_count(<<EOS, 2)
+    assert_detect_interview_count(<<EOS, 2)
 　　■面談回数：　１〜２回
 　　■単価６０万程度（固定）
 EOS
 
     ### 漢数字パターン
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 　　■面談回数：　一回
 　　■単価６０万程度（固定）
 EOS
 
-    assert_detect_interviewing_count(<<EOS, 2)
+    assert_detect_interview_count(<<EOS, 2)
 　　■面談回数：　二回
 　　■単価６０万程度（固定）
 EOS
  
     ### 複数「面談」文言パターン
-    assert_detect_interviewing_count(<<EOS, 1)
+    assert_detect_interview_count(<<EOS, 1)
 ※所属(御社or1社下)、雇用形態(社員or契約or個人)、並行営業状況(提案or面談or結果待ち)をお伝え下さい
 ----------------------------------------------------------------------
 
@@ -150,11 +150,11 @@ EOS
 EOS
  end
 
-  def assert_detect_interviewing_count(body, expected_count)
+  def assert_detect_interview_count(body, expected_count)
     im = ImportMail.new
     im.mail_subject = ""
     im.mail_body = body
     im.analyze
-    assert_equal(expected_count, im.interviewing_count)
+    assert_equal(expected_count, im.interview_count)
   end
 end


### PR DESCRIPTION
import_mailsテーブル フィールド名を interviewing_count => interview_count に修正
面談1回チェックボックスを「フラグ」の行に移動
面談回数1回のメールに「1回」のタグを付与
