### PR TITLE
delivery_mails bug fix

### DIFF
--- a/app/controllers/delivery_mails_controller.rb
+++ b/app/controllers/delivery_mails_controller.rb
@@ -44,8 +44,8 @@ class DeliveryMailsController < ApplicationController
   end
 
   def copynew
-    @src_mail_id = params[:id]
-    src_mail = DeliveryMail.find(@src_mail_id)
+    params[:src_mail_id] = params[:id]
+    src_mail = DeliveryMail.find(params[:src_mail_id])
     src_mail.setup_planned_setting_at(current_user.zone_at(src_mail.planned_setting_at))
     @attachment_files = AttachmentFile.get_attachment_files("delivery_mails", src_mail.id)
     @delivery_mail = DeliveryMail.new
@@ -191,15 +191,22 @@ EOS
             notice: 'Delivery mail was successfully created.')
           }
         end
-        format.html {
-          redirect_to url_for(
-            :controller => 'bp_pic_groups',
-            :action => 'show',
-            :id => @delivery_mail.bp_pic_group_id,
-            :delivery_mail_id => @delivery_mail.id,
-            :back_to => back_to
-          ),
-        notice: 'Delivery mail was successfully updated.' }
+
+        if @delivery_mail.instant?
+          format.html {
+            redirect_to back_to,
+            notice: 'Delivery mail was successfully updated.' }
+        else
+          format.html {
+            redirect_to url_for(
+              :controller => 'bp_pic_groups',
+              :action => 'show',
+              :id => @delivery_mail.bp_pic_group_id,
+              :delivery_mail_id => @delivery_mail.id,
+              :back_to => back_to
+            ),
+            notice: 'Delivery mail was successfully updated.' }
+        end
         format.json { head :no_content }
       rescue ActiveRecord::RecordInvalid
         format.html { render action: "edit" }
@@ -290,7 +297,7 @@ EOS
 
   def reply_mail_new
     @bp_pics = []
-    source_subject, source_content, @source_bp_pic_id, @source_message_id =
+    source_subject, source_content, params[:source_bp_pic_id], params[:source_message_id] =
       if params[:import_mail_id]
         source_im = ImportMail.find(params[:import_mail_id])
         [source_im.mail_subject, source_im.mail_body, source_im.bp_pic_id, source_im.message_id]
@@ -303,6 +310,7 @@ EOS
       end
 
     @delivery_mail = DeliveryMail.new
+    @delivery_mail.delivery_mail_type = "instant"
     @delivery_mail.mail_bcc = current_user.email
 
     new_proc
@@ -354,14 +362,7 @@ EOS
 =end
 
         format.html {
-          redirect_to url_for(
-            :controller => 'delivery_mails',
-            :action => 'show',
-            :id => @delivery_mail.id,
-            :back_to => back_to
-          ),
-          notice: 'Delivery mail was successfully sent.'
-#          redirect_to(back_to , notice: 'Delivery mail was successfully created.')
+          redirect_to(back_to , notice: 'Delivery mail was successfully sent.')
         }
       rescue ActiveRecord::RecordInvalid
         format.html { render action: "new" }
@@ -372,6 +373,7 @@ EOS
   def contact_mail_new
     @bp_pics = BpPic.find(params[:bp_pic_ids])
     @delivery_mail = DeliveryMail.new
+    @delivery_mail.delivery_mail_type = "instant"
     #@delivery_mail.bp_pic_group_id = params[:id]
     unless sales_pic = BpPic.find(params[:bp_pic_ids][0]).sales_pic
       sales_pic = current_user
@@ -438,14 +440,7 @@ EOS
 =end
 
         format.html {
-          redirect_to url_for(
-            :controller => 'delivery_mails',
-            :action => 'show',
-            :id => @delivery_mail.id,
-            :back_to => back_to
-          ),
-          notice: 'Delivery mail was successfully sent.'
-#          redirect_to(back_to , notice: 'Delivery mail was successfully created.')
+          redirect_to(back_to , notice: 'Delivery mail was successfully sent.')
         }
       rescue ActiveRecord::RecordInvalid
         format.html { render action: "new" }

--- a/app/models/delivery_mail.rb
+++ b/app/models/delivery_mail.rb
@@ -14,7 +14,7 @@ class DeliveryMail < ActiveRecord::Base
   has_many :delivery_mail_targets, :conditions => "delivery_mail_targets.deleted = 0"
 
   belongs_to :bp_pic_group
-  attr_accessible :bp_pic_group_id, :content, :id, :mail_bcc, :mail_cc, :mail_from, :mail_from_name, :mail_send_status_type, :mail_status_type, :owner_id, :planned_setting_at, :send_end_at, :subject, :lock_version, :planned_setting_at_hour, :planned_setting_at_minute, :planned_setting_at_date, :delivery_mail_type, :biz_offer_id, :bp_member_id, :formated_mail_from, :age, :payment, :import_mail_match_id, :matching_way_type
+  attr_accessible :bp_pic_group_id, :content, :id, :mail_bcc, :mail_cc, :mail_from, :mail_from_name, :mail_send_status_type, :mail_status_type, :owner_id, :planned_setting_at, :send_end_at, :subject, :lock_version, :planned_setting_at_hour, :planned_setting_at_minute, :planned_setting_at_date, :delivery_mail_type, :biz_offer_id, :bp_member_id, :formated_mail_from, :age, :payment, :import_mail_match_id, :matching_way_type, :tag_text, :auto_matching_last_id
 
   validates_presence_of :subject, :content, :mail_from_name, :mail_from, :planned_setting_at
 
@@ -24,6 +24,10 @@ class DeliveryMail < ActiveRecord::Base
 
   def get_delivery_mail_targets(limit=20)
     DeliveryMailTarget.joins("left outer join import_mails on import_mails.in_reply_to = delivery_mail_targets.message_id").where("delivery_mail_targets.delivery_mail_id = ? and delivery_mail_targets.deleted = 0", self.id).order("import_mails.in_reply_to desc, delivery_mail_targets.delivery_mail_id").limit(limit)
+  end
+
+  def instant?
+    self.delivery_mail_type == "instant"
   end
 
   def group?

--- a/app/views/delivery_mails/_form.html.erb
+++ b/app/views/delivery_mails/_form.html.erb
@@ -1,5 +1,5 @@
-<%= hidden_field_tag 'source_bp_pic_id', @source_bp_pic_id %>
-<%= hidden_field_tag 'source_message_id', @source_message_id %>
+<%= hidden_field_tag 'source_bp_pic_id', params[:source_bp_pic_id] %>
+<%= hidden_field_tag 'source_message_id', params[:source_message_id] %>
 <%= hidden_field_tag 'delivery_mail[matching_way_type]', (params[:matching_way_type] || 'other') %>
 <%= hidden_field_tag 'delivery_mail[import_mail_match_id]', params[:import_mail_match_id] %>
 <%= back_to_field_tag %>
@@ -101,7 +101,7 @@
       <%= f.text_area :content, :style => "width:90%" , :onFocus => "xtarget = this;" %>
     </td>
   </tr>
-  <% unless @bp_pics %>
+  <% unless @delivery_mail.instant? %>
   <tr>
     <th><%= f.label :planned_setting_at, getLongName('delivery_mails', 'planned_setting_at') %></th>
     <td>
@@ -114,13 +114,13 @@
 </table>
 
 <div class="actions">
-  <%= hidden_field_tag 'src_mail_id', @src_mail_id %>
+  <%= hidden_field_tag 'src_mail_id', params[:src_mail_id] %>
   <%= hidden_field 'delivery_mail', 'bp_pic_group_id' %>
   <%= hidden_field_tag 'bp_pic_ids', params[:bp_pic_ids] %>
-  <% unless @bp_pics %>
-    <%= f.submit(:value => 'メールを作成し、対象者選択へ進む', :class => "btn btn-primary btn-medium") %> <%= f.submit(:name => 'testmail', :value => 'テストメールを送信する', :confirm => "一旦メールを保存し、送信者宛てにテストメールを送信してこの画面に戻ります。", :class => "btn btn-info btn-medium") %>
+  <% if @delivery_mail.instant? %>
+    <%= f.submit(:value => 'メールを送信する', :class => "btn btn-info btn-medium") %>
   <% else %>
-    <%= f.submit(:value => 'メールを送信する') %>
+    <%= f.submit(:value => 'メールを作成し、対象者選択へ進む', :class => "btn btn-primary btn-medium") %> <%= f.submit(:name => 'testmail', :value => 'テストメールを送信する', :confirm => "一旦メールを保存し、送信者宛てにテストメールを送信してこの画面に戻ります。", :class => "btn btn-info btn-medium") %>
   <% end %>
 </div>
 

--- a/app/views/delivery_mails/_show_line.html.erb
+++ b/app/views/delivery_mails/_show_line.html.erb
@@ -23,8 +23,13 @@
       %></td>
     <% else %>
       <td>
-        <% delivery_mail_target.reply_mails.each_with_index do |import_mail, idx| %>
-          <%= back_to_link "詳細#{idx+1}", :controller => :import_mail, :action => :show, :id => import_mail.id %> 
+        <%# 外部キーがnilだとdelivery_mail_target.reply_mailsが全件取れてしまうので、blank判定を入れている %>
+        <% if delivery_mail_target.message_id.blank? %>
+          &nbsp;
+        <% else %>
+          <% delivery_mail_target.reply_mails.each_with_index do |import_mail, idx| %>
+            <%= back_to_link "詳細#{idx+1}", :controller => :import_mail, :action => :show, :id => import_mail.id %>
+          <% end %>
         <% end %>
       </td>
     <% end %>


### PR DESCRIPTION
- 配信メール編集時、即席メールもbp_pic_groupsに遷移していたので前画面に戻るよう修正
- 配信メールで即時配信しないようになった絡みで、message_idに値が入らない状態で詳細画面を見た時にreply_mailsが全件取得されてしまうバグ修正
- メールコピー時に落ちるバグ修正
- メールコピー作成・返信メール作成時、入力エラーになるとhidden値が消えてしまうバグ修正
